### PR TITLE
Remove empty fields from generic fields

### DIFF
--- a/adwords_campaign_overview.dashboard.lookml
+++ b/adwords_campaign_overview.dashboard.lookml
@@ -646,9 +646,4 @@
   - name: Date
     title: Date
     type: date_filter
-
-    model:
-    explore:
-    field:
-    listens_to_filters: []
     allow_multiple_values: true


### PR DESCRIPTION
The empty fields on the generic filter were causing lookml warnings and would not let me validate.